### PR TITLE
Issue21

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,37 +15,7 @@ My motivation for creating this library was that I could not find one that had t
 
 ## Example
 
-```
-package main
-
-import (
-    "fmt"
-    "github.com/kckeiks/netlink/sockdiag"
-    "golang.org/x/sys/unix"
-)
-
-func main() {
-	inetReq := sockdiag.InetDiagReqV2{
-		Family: unix.AF_INET,
-		Protocol: unix.IPPROTO_TCP,
-		States: ^uint32(0),
-	}
-
-	h := unix.NlMsghdr{
-		Len: sockdiag.NlInetDiagReqV2MsgLen,
-		Type: sockdiag.SOCK_DIAG_BY_FAMILY,
-		Flags: (unix.NLM_F_REQUEST | unix.NLM_F_DUMP),
-		Pid: 0,
-	}
-
-	nlmsg := sockdiag.NewInetNetlinkMsg(h, inetReq)
-
-	for _, msg := range sockdiag.SendInetMessage(nlmsg) {
-		fmt.Printf("InetDiagMsg: %+v\n", msg)
-	}
-}
-
-```
+In the playground directory, you can find different examples on how these packages are used.
 
 ## Work In Progress
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	h := unix.NlMsghdr{
-		Len: sockdiag.NL_INET_DIAG_REQ_V2_MSG_LEN,
+		Len: sockdiag.NlInetDiagReqV2MsgLen,
 		Type: sockdiag.SOCK_DIAG_BY_FAMILY,
 		Flags: (unix.NLM_F_REQUEST | unix.NLM_F_DUMP),
 		Pid: 0,

--- a/internal/testutils/netlink.go
+++ b/internal/testutils/netlink.go
@@ -10,7 +10,7 @@ var TestByteOrder = binary.LittleEndian
 func NewTestNlMsghdr() unix.NlMsghdr {
 	h := unix.NlMsghdr{}
 	h.Len = unix.NLMSG_HDRLEN 
-	h.Type = 2
+	h.Type = 0
 	h.Flags = 5
 	h.Seq = 6
 	h.Pid = 11

--- a/netlink.go
+++ b/netlink.go
@@ -8,12 +8,11 @@ import (
 	"errors"
 )
 
+var ByteOrder = binary.LittleEndian
 var NlmsgAlignTo uint32 = 4
 var OSPageSize = os.Getpagesize()
 var NlMsgDoesNotFit = errors.New("nlmsg does not fit into buffer")
 var NlMsgHeaderError = errors.New("nlmsghdr error")
-
-
 
 type NetlinkMessage struct {
 	Header unix.NlMsghdr

--- a/netlink.go
+++ b/netlink.go
@@ -8,9 +8,13 @@ import (
 )
 
 var ByteOrder = binary.LittleEndian
+
 var NlmsgAlignTo uint32 = 4
-var NlMsgDoesNotFit = errors.New("nlmsg does not fit into buffer")
-var NlMsgHeaderError = errors.New("nlmsghdr error")
+
+var (
+	NlMsgDoesNotFit = errors.New("nlmsg does not fit into buffer")
+	NlMsgHeaderError = errors.New("nlmsghdr error")
+)
 
 type NetlinkMessage struct {
 	Header unix.NlMsghdr

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -13,10 +13,8 @@ func TestNewSerializedNetlinkMessage(t *testing.T) {
 	h := testutils.NewTestNlMsghdr()
 	// Given: length of nl msg with 4 more bytes of space 
 	h.Len = 16 + 4
-
 	// When: we serialize the header and the data
 	serializedData := NewSerializedNetlinkMessage(h)
-
 	// Then: the message was serialized with the correct data
 	if h.Len != testutils.TestByteOrder.Uint32(serializedData[:4]) {
 		t.Fatalf("NlMsghdr.Length = %d, expected %d", testutils.TestByteOrder.Uint32(serializedData[:4]), h.Len)
@@ -102,18 +100,14 @@ func TestParseNetlinkMessage(t *testing.T) {
 	h2 := testutils.NewTestNlMsghdr()
 	data2 := [8]byte{0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x01, 0x02, 0x02}
 	h2.Len = h2.Len + uint32(len(data2))
-
 	var nlmsgs []byte
 	nlmsgs = append(nlmsgs, testutils.NewTestSerializedNetlinkMsg(h1, data1[:])...)
 	nlmsgs = append(nlmsgs, testutils.NewTestSerializedNetlinkMsg(h2, data2[:])...)
-
 	// When: parse these serialized data
 	result, _ := ParseNetlinkMessage(nlmsgs)
-
 	// Then: We get the messages as expected
 	expectedNlMsg1 := NetlinkMessage{Header: h1, Payload: data1[:]}
 	expectedNlMsg2 := NetlinkMessage{Header: h2, Payload: data2[:]}
-
 	if !reflect.DeepEqual(result[0], expectedNlMsg1) {
 		t.Fatalf("Given first Netlink Msg %+v but received %+v,", result[0], expectedNlMsg1)
 	}
@@ -127,14 +121,12 @@ func TestNlmAlignOf(t *testing.T) {
 	var divisor uint32 = 20
 	// Given: a int that is not a divisor of 4
 	var notdivisor uint32 = 22
-
 	// When: we try to round up the integer
 	result := nlmAlignOf(divisor)
 	// Then: we get the same number
 	if result != divisor {
 		t.Fatalf("Received %d but expected %d", result, divisor)
 	}
-	
 	// When: we round up the integers 
 	result = nlmAlignOf(notdivisor)
 	// THen: we round up so that it's divisible by 4

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -46,7 +46,7 @@ func TestDeserializeNetlinkMsg(t *testing.T) {
 	nlmsg, err := DeserializeNetlinkMsg(serializedData)
 	// Then: there is no error
 	if err != nil {
-		t.Fatalf("Rcvd an unexpected error.")
+		t.Fatalf("got an unexpected error %v.", err)
 	}
 	// Then: the struct that we get has the same values as the initial struct
 	if !reflect.DeepEqual(nlmsg.Header, h) {
@@ -68,7 +68,7 @@ func TestDeserializeNetlinkMsgWithOutData(t *testing.T) {
 	nlmsg, err := DeserializeNetlinkMsg(serializedData)
 	// Then: there is no error
 	if err != nil {
-		t.Fatalf("Rcvd an unexpected error.")
+		t.Fatalf("got an unexpected error %v.", err)
 	}
 	// Then: empty slice is returned for payload
 	if len(nlmsg.Payload) != 0 {

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -104,7 +104,7 @@ func TestParseNetlinkMessage(t *testing.T) {
 	nlmsgs = append(nlmsgs, testutils.NewTestSerializedNetlinkMsg(h2, data2[:])...)
 
 	// When: parse these serialized data
-	result := ParseNetlinkMessage(nlmsgs)
+	result, _ := ParseNetlinkMessage(nlmsgs)
 
 	// Then: We get the messages as expected
 	expectedNlMsg1 := NetlinkMessage{Header: h1, Payload: data1[:]}
@@ -120,9 +120,9 @@ func TestParseNetlinkMessage(t *testing.T) {
 
 func TestNlmAlignOf(t *testing.T) {
 	// Given: a int that is a divisor of 4
-	var divisor int = 20
+	var divisor uint32 = 20
 	// Given: a int that is not a divisor of 4
-	var notdivisor int = 22
+	var notdivisor uint32 = 22
 
 	// When: we try to round up the integer
 	result := nlmAlignOf(divisor)

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -44,10 +44,12 @@ func TestDeserializeNetlinkMsg(t *testing.T) {
 	data := [4]byte{0xFF, 0xFF, 0xFF, 0xFF}
 	h.Len = h.Len + uint32(len(data))
 	serializedData := testutils.NewTestSerializedNetlinkMsg(h, data[:])
-	
 	// When: we deserialize the message
-	nlmsg := DeserializeNetlinkMsg(serializedData)
-
+	nlmsg, err := DeserializeNetlinkMsg(serializedData)
+	// Then: there is no error
+	if err != nil {
+		t.Fatalf("Rcvd an unexpected error.")
+	}
 	// Then: the struct that we get has the same values as the initial struct
 	if !reflect.DeepEqual(nlmsg.Header, h) {
 		t.Fatalf("Given NlMsghdr %+v and deserialized is %+v,", nlmsg.Header, h)
@@ -64,10 +66,12 @@ func TestDeserializeNetlinkMsgWithOutData(t *testing.T) {
 	data := []byte{} 
 	h.Len = uint32(unix.NLMSG_HDRLEN )
 	serializedData := testutils.NewTestSerializedNetlinkMsg(h, data)
-	
 	// When: we deserialize the message
-	nlmsg := DeserializeNetlinkMsg(serializedData)
-
+	nlmsg, err := DeserializeNetlinkMsg(serializedData)
+	// Then: there is no error
+	if err != nil {
+		t.Fatalf("Rcvd an unexpected error.")
+	}
 	// Then: empty slice is returned for payload
 	if len(nlmsg.Payload) != 0 {
 		t.Fatalf("Extra data=%d, expected [].", nlmsg.Payload)

--- a/order.go
+++ b/order.go
@@ -1,5 +1,0 @@
-package netlink
-
-import	"encoding/binary"
-
-var ByteOrder = binary.LittleEndian

--- a/playground/play.go
+++ b/playground/play.go
@@ -22,7 +22,9 @@ func main() {
 
 	nlmsg := sockdiag.NewInetNetlinkMsg(h, inetReq)
 
-	for _, msg := range sockdiag.SendInetMessage(nlmsg) {
+	result, _ := sockdiag.SendInetMessage(nlmsg)
+
+	for _, msg := range result {
 		fmt.Printf("InetDiagMsg: %+v\n", msg)
 	}
 }

--- a/playground/play.go
+++ b/playground/play.go
@@ -22,7 +22,8 @@ func SendInetMessage(nlmsg []byte) ([]sockdiag.InetDiagMsg, error) {
 	}
 	var idmsgs []sockdiag.InetDiagMsg
 	for _, msg := range nlmsgs {
-		idmsgs = append(idmsgs, sockdiag.DeserializeInetDiagMsg(msg.Payload))
+		inetMsg, _ := sockdiag.DeserializeInetDiagMsg(msg.Payload)
+		idmsgs = append(idmsgs, *inetMsg)
 	}
 	return idmsgs, nil
 }

--- a/playground/play.go
+++ b/playground/play.go
@@ -8,7 +8,6 @@ import (
 	"os"
 )
 
-
 func SendInetMessage(nlmsg []byte) ([]sockdiag.InetDiagMsg, error) {
 	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_SOCK_DIAG)
 	if err != nil {
@@ -27,7 +26,6 @@ func SendInetMessage(nlmsg []byte) ([]sockdiag.InetDiagMsg, error) {
 	}
 	return idmsgs, nil
 }
-
 
 func ReceiveNetlinkMessage(fd int) ([]netlink.NetlinkMessage, error) {
 	nlmsgs := make([]netlink.NetlinkMessage, 0)
@@ -61,18 +59,14 @@ func main() {
 		Protocol: unix.IPPROTO_TCP,
 		States: ^uint32(0),
 	}
-
 	h := unix.NlMsghdr{
 		Len: sockdiag.NlInetDiagReqV2MsgLen,
 		Type: sockdiag.SOCK_DIAG_BY_FAMILY,
 		Flags: (unix.NLM_F_REQUEST | unix.NLM_F_DUMP),
 		Pid: 0,
 	}
-
 	nlmsg, _ := sockdiag.NewInetNetlinkMsg(h, inetReq)
-
 	result, _ := SendInetMessage(nlmsg)
-
 	for _, msg := range result {
 		fmt.Printf("InetDiagMsg: %+v\n", msg)
 	}

--- a/playground/play.go
+++ b/playground/play.go
@@ -62,13 +62,13 @@ func main() {
 	}
 
 	h := unix.NlMsghdr{
-		Len: sockdiag.NL_INET_DIAG_REQ_V2_MSG_LEN,
+		Len: sockdiag.NlInetDiagReqV2MsgLen,
 		Type: sockdiag.SOCK_DIAG_BY_FAMILY,
 		Flags: (unix.NLM_F_REQUEST | unix.NLM_F_DUMP),
 		Pid: 0,
 	}
 
-	nlmsg := sockdiag.NewInetNetlinkMsg(h, inetReq)
+	nlmsg, _ := sockdiag.NewInetNetlinkMsg(h, inetReq)
 
 	result, _ := SendInetMessage(nlmsg)
 

--- a/sockdiag/inet.go
+++ b/sockdiag/inet.go
@@ -82,7 +82,7 @@ func SendInetMessage(nlmsg []byte) []InetDiagMsg {
 	}
 	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK}
 	unix.Sendto(fd, nlmsg, 0, addr)
-	nlmsgs := netlink.ReceiveMultipartMessage(fd)
+	nlmsgs := netlink.ReceiveNetlinkMessage(fd)
 	var idmsgs []InetDiagMsg
 	for _, msg := range nlmsgs {
 		idmsgs = append(idmsgs, DeserializeInetDiagMsg(msg.Payload))

--- a/sockdiag/inet.go
+++ b/sockdiag/inet.go
@@ -73,22 +73,3 @@ func DeserializeInetDiagMsg(data []byte) InetDiagMsg {
 	}
 	return msg 
 }
-
-
-func SendInetMessage(nlmsg []byte) ([]InetDiagMsg, error) {
-	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_SOCK_DIAG)
-	if err != nil {
-		panic("Error creating socket.")
-	}
-	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK}
-	unix.Sendto(fd, nlmsg, 0, addr)
-	nlmsgs, err := netlink.ReceiveNetlinkMessage(fd)
-	if err != nil {
-		return nil, err
-	}
-	var idmsgs []InetDiagMsg
-	for _, msg := range nlmsgs {
-		idmsgs = append(idmsgs, DeserializeInetDiagMsg(msg.Payload))
-	}
-	return idmsgs, nil
-}

--- a/sockdiag/inet.go
+++ b/sockdiag/inet.go
@@ -52,27 +52,30 @@ func NewInetNetlinkMsg(nlHeader unix.NlMsghdr, inetHeader InetDiagReqV2) ([]byte
 		return nil, InetMsgLenError
 	}
 	msg := netlink.NewSerializedNetlinkMessage(nlHeader)
-	ih := SerializeInetDiagReqV2(inetHeader)
+	ih, err := SerializeInetDiagReqV2(inetHeader)
+	if err != nil {
+		return nil, err
+	}
 	copy(msg[unix.NLMSG_HDRLEN :], ih)
 	return msg, nil
 }
 
-func SerializeInetDiagReqV2(req InetDiagReqV2) []byte {
+func SerializeInetDiagReqV2(req InetDiagReqV2) ([]byte, error) {
 	b := bytes.NewBuffer(make([]byte, InetDiagReqV2Len))
 	b.Reset()
 	err := binary.Write(b, netlink.ByteOrder, req)
 	if err != nil {
-		panic("Error: failed to serialize InetDiagReqV2.")
+		return nil, err
 	}
-	return b.Bytes()
+	return b.Bytes(), nil
 }
 
-func DeserializeInetDiagMsg(data []byte) InetDiagMsg {
+func DeserializeInetDiagMsg(data []byte) (*InetDiagMsg, error) {
 	msg := InetDiagMsg{}
 	b := bytes.NewBuffer(data)
 	err := binary.Read(b, netlink.ByteOrder, &msg)
 	if err != nil {
-		panic("Error: Could not parse InetDiagMsg.")
+		return nil, err
 	}
-	return msg 
+	return &msg, nil 
 }

--- a/sockdiag/inet.go
+++ b/sockdiag/inet.go
@@ -75,17 +75,20 @@ func DeserializeInetDiagMsg(data []byte) InetDiagMsg {
 }
 
 
-func SendInetMessage(nlmsg []byte) []InetDiagMsg {
+func SendInetMessage(nlmsg []byte) ([]InetDiagMsg, error) {
 	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_SOCK_DIAG)
 	if err != nil {
 		panic("Error creating socket.")
 	}
 	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK}
 	unix.Sendto(fd, nlmsg, 0, addr)
-	nlmsgs := netlink.ReceiveNetlinkMessage(fd)
+	nlmsgs, err := netlink.ReceiveNetlinkMessage(fd)
+	if err != nil {
+		return nil, err
+	}
 	var idmsgs []InetDiagMsg
 	for _, msg := range nlmsgs {
 		idmsgs = append(idmsgs, DeserializeInetDiagMsg(msg.Payload))
 	}
-	return idmsgs
+	return idmsgs, nil
 }

--- a/sockdiag/inet.go
+++ b/sockdiag/inet.go
@@ -3,15 +3,18 @@ package sockdiag
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"golang.org/x/sys/unix"
 	"github.com/kckeiks/netlink"
 )
 
 const (
-	INET_DIAG_REQ_V2_LEN        = 56
-	NL_INET_DIAG_REQ_V2_MSG_LEN = 72 // includes netlink header
-	NL_INET_DIAG_MSG_LEN        = 72
+	InetDiagReqV2Len        = 56
+	NlInetDiagReqV2MsgLen   = 72 // includes netlink header
+	NlInetDiagMsgLen        = 72
 )
+
+var InetMsgLenError = errors.New("inet: invalid msg length")
 
 type InetDiagSockID struct {
 	SPort  [2]byte    // source port          __be16  idiag_sport;
@@ -44,18 +47,18 @@ type InetDiagMsg struct {
 	Inode   uint32
 }
 
-func NewInetNetlinkMsg(nlh unix.NlMsghdr, inetHeader InetDiagReqV2) []byte {
-	if nlh.Len != NL_INET_DIAG_REQ_V2_MSG_LEN {
-		panic("Error: Invalid NlMsghdr.Len.")
+func NewInetNetlinkMsg(nlHeader unix.NlMsghdr, inetHeader InetDiagReqV2) ([]byte, error) {
+	if nlHeader.Len != NlInetDiagReqV2MsgLen {
+		return nil, InetMsgLenError
 	}
-	msg := netlink.NewSerializedNetlinkMessage(nlh)
+	msg := netlink.NewSerializedNetlinkMessage(nlHeader)
 	ih := SerializeInetDiagReqV2(inetHeader)
 	copy(msg[unix.NLMSG_HDRLEN :], ih)
-	return msg
+	return msg, nil
 }
 
 func SerializeInetDiagReqV2(req InetDiagReqV2) []byte {
-	b := bytes.NewBuffer(make([]byte, INET_DIAG_REQ_V2_LEN))
+	b := bytes.NewBuffer(make([]byte, InetDiagReqV2Len))
 	b.Reset()
 	err := binary.Write(b, netlink.ByteOrder, req)
 	if err != nil {

--- a/sockdiag/inet_test.go
+++ b/sockdiag/inet_test.go
@@ -66,7 +66,10 @@ func TestSerializeInetDiagReqV2(t *testing.T) {
 	// Given: a inet_diag_req_v2 header
 	req := newTestInetDiagReqV2()
 	// When: we serialize the header
-	serializedData := SerializeInetDiagReqV2(req)
+	serializedData, err := SerializeInetDiagReqV2(req)
+	if err != nil {
+		t.Fatalf("got an unexpected error %v.", err)
+	}
 	// Then: it's serialized with the correct data
 	if req.Family != serializedData[0] {
 		t.Fatalf("InetDiagReqV2.Family = %d, expected %d", serializedData[0], req.Family)
@@ -113,9 +116,13 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 	serializedData.Reset()
 	binary.Write(serializedData, testutils.TestByteOrder, &msg)
 	// When: we deserialize
-	result := DeserializeInetDiagMsg(serializedData.Bytes())
+	result, err := DeserializeInetDiagMsg(serializedData.Bytes())
+	// Then: there is no error
+	if err != nil {
+		t.Fatalf("got an unexpected error %v.", err)
+	}
 	// Then: the struct that we get has the same values as the initial struct
-	if !reflect.DeepEqual(result, msg) {
+	if !reflect.DeepEqual(result, &msg) {
 		t.Fatalf("Given InetDiagMsg %+v but expected %+v,", result, msg)
 	}
 }
@@ -123,7 +130,10 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 func TestDeserializeInetDiagReqV2(t *testing.T) {
 	// Given: a inet_diag_req_v2 header
 	req := newTestInetDiagReqV2()
-	serializedData := SerializeInetDiagReqV2(req)
+	serializedData, err := SerializeInetDiagReqV2(req)
+	if err != nil {
+		t.Fatalf("got an unexpected error %v.", err)
+	}
 	// When: we deserialize
 	result := deserializeInetDiagReqV2(serializedData)
 	// Then: the struct that we get has the same values as the initial struct
@@ -141,7 +151,7 @@ func TestNewInetNetlinkMsg(t *testing.T) {
 	serializedData, err := NewInetNetlinkMsg(h, inetHeader)
 	// Then: there is no error
 	if err != nil {
-		t.Fatalf("unexpected error")
+		t.Fatalf("got an unexpected error %v.", err)
 	}
 	// Then: the message was serialized with the correct data
 	if h.Len != testutils.TestByteOrder.Uint32(serializedData[:4]) {


### PR DESCRIPTION
Remove send and recv functions because there is quite a bit of complexity when implementing generic functions for these. We will let developer implement socket read and write ops on sockets as they see fit for their requirements.